### PR TITLE
Fix goal angle critic threshold

### DIFF
--- a/cfg/GoalAngleCritic.cfg
+++ b/cfg/GoalAngleCritic.cfg
@@ -10,6 +10,6 @@ gen.add("enabled", bool_t, 0, "Distance between robot and goal above which goal 
 gen.add("cost_power", double_t, 0, "Power order to apply to term", 0.0, 0.0, 10000.0)
 gen.add("cost_weight", double_t, 0, "Weight to apply to critic term", 0.0, 0.0, 10000.0)
 
-gen.add("threshold_to_consider", double_t, 0, "Minimal distance between robot and goal above which angle goal cost considered", 0.5, 0.001, 3.14)
+gen.add("threshold_to_consider", double_t, 0, "Minimal distance between robot and goal above which angle goal cost considered", 0.5, 0.001, 10)
 
 exit(gen.generate(PACKAGE, "mppi_controller", "GoalAngleCritic"))


### PR DESCRIPTION
# Description
The parameter is to make the critic to be enabled if robot is within `threshold_to_consider` distance to the goal.
It is in meters, not radians.