### PR TITLE
Fix to update params in computeVelocityCommands

### DIFF
--- a/include/mppi_controller/controller.hpp
+++ b/include/mppi_controller/controller.hpp
@@ -141,6 +141,9 @@ protected:
 
   ros::NodeHandle parent_nh_;
   ros::NodeHandle pnh_;
+
+  std::mutex config_mtx_;
+
   costmap_2d::Costmap2DROS* costmap_ros_;
   tf2_ros::Buffer* tf_buffer_;
   NavTolerances latest_limits_;

--- a/include/mppi_controller/controller.hpp
+++ b/include/mppi_controller/controller.hpp
@@ -137,6 +137,7 @@ protected:
   void visualize(nav_msgs::Path transformed_plan);
 
   void reconfigureCB(const mppi_controller::MPPIControllerConfig& config, uint32_t level);
+  void setParams();
 
   ros::NodeHandle parent_nh_;
   ros::NodeHandle pnh_;
@@ -145,6 +146,8 @@ protected:
   NavTolerances latest_limits_;
   base_local_planner::LocalPlannerUtil planner_util_;
   base_local_planner::OdometryHelperRos odom_helper_;
+  mppi_controller::MPPIControllerConfig config_;
+  bool reconfigure_{ false };
 
   Optimizer optimizer_;
   PathHandler path_handler_;

--- a/include/mppi_controller/optimizer.hpp
+++ b/include/mppi_controller/optimizer.hpp
@@ -221,16 +221,15 @@ protected:
 protected:
   ros::NodeHandle parent_nh_;
 
-  mutable std::mutex param_mtx_;
-
   costmap_2d::Costmap2DROS* costmap_ros_;
 
   std::shared_ptr<MotionModel> motion_model_;
+  bool is_holonomic_{ false };
 
   CriticManager critic_manager_;
-  NoiseGenerator noise_generator_;
 
   models::OptimizerSettings settings_;
+  NoiseGenerator noise_generator_{ settings_, is_holonomic_ };
 
   models::State state_;
   models::ControlSequence control_sequence_;

--- a/include/mppi_controller/tools/path_handler.hpp
+++ b/include/mppi_controller/tools/path_handler.hpp
@@ -142,7 +142,6 @@ protected:
   nav_msgs::Path global_plan_;
   nav_msgs::Path global_plan_up_to_inversion_;
 
-  mutable std::mutex params_mutex_;
   mppi_controller::MPPIControllerConfig config_;
   std::atomic<unsigned int> inversion_locale_{ 0u };
 };

--- a/include/mppi_controller/tools/utils.hpp
+++ b/include/mppi_controller/tools/utils.hpp
@@ -327,6 +327,8 @@ inline void setPathFurthestPointIfNotSet(CriticData& data)
 inline void findPathCosts(CriticData& data, costmap_2d::Costmap2DROS* costmap_ros)
 {
   auto* costmap = costmap_ros->getCostmap();
+  std::unique_lock<costmap_2d::Costmap2D::mutex_t> costmap_lock(*(costmap->getMutex()));
+
   unsigned int map_x, map_y;
   const size_t path_segments_count = data.path.x.shape(0) - 1;
   data.path_pts_valid = std::vector<bool>(path_segments_count, false);

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -79,9 +79,6 @@ uint32_t MPPIController::computeVelocityCommands(const geometry_msgs::PoseStampe
     return error;
   }
 
-  costmap_2d::Costmap2D* costmap = costmap_ros_->getCostmap();
-  std::unique_lock<costmap_2d::Costmap2D::mutex_t> costmap_lock(*(costmap->getMutex()));
-
   if (uint32_t error = optimizer_.evalControl(robot_pose, robot_speed.twist, transformed_plan, cmd_vel);
       error != mbf_msgs::ExePathResult::SUCCESS)
   {

--- a/src/optimizer.cpp
+++ b/src/optimizer.cpp
@@ -42,8 +42,7 @@ void Optimizer::initialize(const ros::NodeHandle& parent_nh, costmap_2d::Costmap
   critic_manager_.on_configure(parent_nh_, costmap_ros_);
 
   models::OptimizerSettings default_settings;
-  noise_generator_.initialize(parent_nh_, default_settings, false);
-  setParams(config);
+  // setParams(config);
 }
 
 void Optimizer::shutdown()
@@ -53,39 +52,36 @@ void Optimizer::shutdown()
 
 void Optimizer::setParams(const mppi_controller::MPPIControllerConfig& config)
 {
-  {
-    std::lock_guard<std::mutex> lock(param_mtx_);
-    auto& s = settings_;
-    s.model_dt = config.model_dt;
-    s.time_steps = config.time_steps;
-    s.batch_size = config.batch_size;
-    s.iteration_count = config.iteration_count;
-    s.temperature = config.temperature;
-    s.gamma = config.gamma;
-    s.retry_attempt_limit = config.retry_attempt_limit;
-    s.base_constraints.vx_max = config.vx_max;
-    s.base_constraints.vx_min = config.vx_min;
-    s.base_constraints.vy = config.vy_max;
-    s.base_constraints.wz = config.wz_max;
-    s.sampling_std.vx = config.vx_std;
-    s.sampling_std.vy = config.vy_std;
-    s.sampling_std.wz = config.wz_std;
-    s.constraints = s.base_constraints;
+  auto& s = settings_;
+  s.model_dt = config.model_dt;
+  s.time_steps = config.time_steps;
+  s.batch_size = config.batch_size;
+  s.iteration_count = config.iteration_count;
+  s.temperature = config.temperature;
+  s.gamma = config.gamma;
+  s.retry_attempt_limit = config.retry_attempt_limit;
+  s.base_constraints.vx_max = config.vx_max;
+  s.base_constraints.vx_min = config.vx_min;
+  s.base_constraints.vy = config.vy_max;
+  s.base_constraints.wz = config.wz_max;
+  s.sampling_std.vx = config.vx_std;
+  s.sampling_std.vy = config.vy_std;
+  s.sampling_std.wz = config.wz_std;
+  s.constraints = s.base_constraints;
 
-    ROS_DEBUG_NAMED("Optimizer",
-                    "Updating setting params: model_dt: %f, time_steps: %d, batch_size: %d, "
-                    "iteration_count: %d, temperature: %f, gamma: %f, retry_attempt_limit: %d, "
-                    "vx_max: %f, vx_min: %f, vy_max: %f, wz_max: %f, vx_std: %f, vy_std: %f, "
-                    "wz_std: %f",
-                    s.model_dt, s.time_steps, s.batch_size, s.iteration_count, s.temperature, s.gamma,
-                    s.retry_attempt_limit, s.base_constraints.vx_max, s.base_constraints.vx_min, s.base_constraints.vy,
-                    s.base_constraints.wz, s.sampling_std.vx, s.sampling_std.vy, s.sampling_std.wz);
-  }
+  ROS_DEBUG_NAMED("Optimizer",
+                  "Updating setting params: model_dt: %f, time_steps: %d, batch_size: %d, "
+                  "iteration_count: %d, temperature: %f, gamma: %f, retry_attempt_limit: %d, "
+                  "vx_max: %f, vx_min: %f, vy_max: %f, wz_max: %f, vx_std: %f, vy_std: %f, "
+                  "wz_std: %f",
+                  s.model_dt, s.time_steps, s.batch_size, s.iteration_count, s.temperature, s.gamma,
+                  s.retry_attempt_limit, s.base_constraints.vx_max, s.base_constraints.vx_min, s.base_constraints.vy,
+                  s.base_constraints.wz, s.sampling_std.vx, s.sampling_std.vy, s.sampling_std.wz);
 
   setMotionModel(config.motion_model);
   setOffset(config.controller_frequency);
-  reset();
   noise_generator_.setParams(config);
+  reset();
 }
 
 void Optimizer::setOffset(double controller_frequency)
@@ -93,8 +89,6 @@ void Optimizer::setOffset(double controller_frequency)
   const double controller_period = 1.0 / controller_frequency;
   constexpr double eps = 1e-6;
 
-  {
-    std::lock_guard<std::mutex> lock(param_mtx_);
     if ((controller_period + eps) < settings_.model_dt)
     {
       ROS_WARN("Controller period is less then model dt, consider setting it equal");
@@ -109,29 +103,21 @@ void Optimizer::setOffset(double controller_frequency)
       ROS_WARN("Controller period is more then model dt, we ignore and consider it equal");
       settings_.shift_control_sequence = true;
     }
-  }
 }
 
 void Optimizer::reset()
 {
-  mppi::models::OptimizerSettings settings_copy;
-  {
-    std::lock_guard<std::mutex> lock(param_mtx_);
-    settings_copy = settings_;
-  }
-
-  state_.reset(settings_copy.batch_size, settings_copy.time_steps);
-  control_sequence_.reset(settings_copy.time_steps);
+  state_.reset(settings_.batch_size, settings_.time_steps);
+  control_sequence_.reset(settings_.time_steps);
   control_history_[0] = { 0.0, 0.0, 0.0 };
   control_history_[1] = { 0.0, 0.0, 0.0 };
   control_history_[2] = { 0.0, 0.0, 0.0 };
   control_history_[3] = { 0.0, 0.0, 0.0 };
 
-  costs_ = xt::zeros<float>({ settings_copy.batch_size });
-  generated_trajectories_.reset(settings_copy.batch_size, settings_copy.time_steps);
+  costs_ = xt::zeros<float>({ settings_.batch_size });
+  generated_trajectories_.reset(settings_.batch_size, settings_.time_steps);
 
-  noise_generator_.reset(settings_copy, isHolonomic());
-  critic_manager_.updateConstraints(settings_copy.constraints);
+  critic_manager_.updateConstraints(settings_.constraints);
   ROS_INFO("Optimizer reset");
 }
 
@@ -154,16 +140,10 @@ uint32_t Optimizer::evalControl(const geometry_msgs::PoseStamped& robot_pose, co
     }
   }
 
-  mppi::models::OptimizerSettings settings;
-  {
-    std::lock_guard<std::mutex> lock(param_mtx_);
-    settings = settings_;
-  }
-
-  utils::savitskyGolayFilter(control_sequence_, control_history_, settings);
+  utils::savitskyGolayFilter(control_sequence_, control_history_, settings_);
   cmd_vel = getControlFromSequenceAsTwist(plan.header);
 
-  if (settings.shift_control_sequence)
+  if (settings_.shift_control_sequence)
   {
     shiftControlSequence();
   }
@@ -173,13 +153,7 @@ uint32_t Optimizer::evalControl(const geometry_msgs::PoseStamped& robot_pose, co
 
 void Optimizer::optimize()
 {
-  int iteration_count;
-  {
-    std::lock_guard<std::mutex> lock(param_mtx_);
-    iteration_count = settings_.iteration_count;
-  }
-
-  for (size_t i = 0; i < iteration_count; ++i)
+  for (size_t i = 0; i < settings_.iteration_count; ++i)
   {
     generateNoisedTrajectories();
     critic_manager_.evalTrajectoriesScores(critics_data_);
@@ -199,13 +173,7 @@ bool Optimizer::fallback(bool fail, uint32_t& error)
 
   reset();
 
-  int retry_attempt_limit;
-  {
-    std::lock_guard<std::mutex> lock(param_mtx_);
-    retry_attempt_limit = settings_.retry_attempt_limit;
-  }
-
-  if (++counter > retry_attempt_limit)
+  if (++counter > settings_.retry_attempt_limit)
   {
     counter = 0;
     ROS_ERROR_NAMED("Optimizer", "Optimizer fail to compute path");
@@ -257,24 +225,18 @@ void Optimizer::generateNoisedTrajectories()
 
 bool Optimizer::isHolonomic() const
 {
-  return motion_model_->isHolonomic();
+  return is_holonomic_;
 }
 
 void Optimizer::applyControlSequenceConstraints()
 {
-  mppi::models::ControlConstraints constraints;
-  {
-    std::lock_guard<std::mutex> lock(param_mtx_);
-    constraints = settings_.constraints;
-  }
-
   if (isHolonomic())
   {
-    control_sequence_.vy = xt::clip(control_sequence_.vy, -constraints.vy, constraints.vy);
+    control_sequence_.vy = xt::clip(control_sequence_.vy, -settings_.constraints.vy, settings_.constraints.vy);
   }
 
-  control_sequence_.vx = xt::clip(control_sequence_.vx, constraints.vx_min, constraints.vx_max);
-  control_sequence_.wz = xt::clip(control_sequence_.wz, -constraints.wz, constraints.wz);
+  control_sequence_.vx = xt::clip(control_sequence_.vx, settings_.constraints.vx_min, settings_.constraints.vx_max);
+  control_sequence_.wz = xt::clip(control_sequence_.wz, -settings_.constraints.wz, settings_.constraints.wz);
 
   motion_model_->applyConstraints(control_sequence_);
 }
@@ -303,12 +265,6 @@ void Optimizer::propagateStateVelocitiesFromInitials(models::State& state) const
 
 void Optimizer::integrateStateVelocities(xt::xtensor<float, 2>& trajectory, const xt::xtensor<float, 2>& sequence) const
 {
-  double model_dt;
-  {
-    std::lock_guard<std::mutex> lock(param_mtx_);
-    model_dt = settings_.model_dt;
-  }
-
   float initial_yaw = tf2::getYaw(state_.pose.pose.orientation);
 
   const auto vx = xt::view(sequence, xt::all(), 0);
@@ -319,7 +275,7 @@ void Optimizer::integrateStateVelocities(xt::xtensor<float, 2>& trajectory, cons
   auto traj_y = xt::view(trajectory, xt::all(), 1);
   auto traj_yaws = xt::view(trajectory, xt::all(), 2);
 
-  xt::noalias(traj_yaws) = xt::cumsum(wz * model_dt, 0) + initial_yaw;
+  xt::noalias(traj_yaws) = xt::cumsum(wz * settings_.model_dt, 0) + initial_yaw;
 
   auto&& yaw_cos = xt::xtensor<float, 1>::from_shape(traj_yaws.shape());
   auto&& yaw_sin = xt::xtensor<float, 1>::from_shape(traj_yaws.shape());
@@ -340,21 +296,15 @@ void Optimizer::integrateStateVelocities(xt::xtensor<float, 2>& trajectory, cons
     dy = dy + vy * yaw_cos;
   }
 
-  xt::noalias(traj_x) = state_.pose.pose.position.x + xt::cumsum(dx * model_dt, 0);
-  xt::noalias(traj_y) = state_.pose.pose.position.y + xt::cumsum(dy * model_dt, 0);
+  xt::noalias(traj_x) = state_.pose.pose.position.x + xt::cumsum(dx * settings_.model_dt, 0);
+  xt::noalias(traj_y) = state_.pose.pose.position.y + xt::cumsum(dy * settings_.model_dt, 0);
 }
 
 void Optimizer::integrateStateVelocities(models::Trajectories& trajectories, const models::State& state) const
 {
-  double model_dt;
-  {
-    std::lock_guard<std::mutex> lock(param_mtx_);
-    model_dt = settings_.model_dt;
-  }
-
   const float initial_yaw = tf2::getYaw(state.pose.pose.orientation);
 
-  xt::noalias(trajectories.yaws) = xt::cumsum(state.wz * model_dt, 1) + initial_yaw;
+  xt::noalias(trajectories.yaws) = xt::cumsum(state.wz * settings_.model_dt, 1) + initial_yaw;
 
   const auto yaws_cutted = xt::view(trajectories.yaws, xt::all(), xt::range(0, -1));
 
@@ -374,21 +324,15 @@ void Optimizer::integrateStateVelocities(models::Trajectories& trajectories, con
     dy = dy + state.vy * yaw_cos;
   }
 
-  xt::noalias(trajectories.x) = state.pose.pose.position.x + xt::cumsum(dx * model_dt, 1);
-  xt::noalias(trajectories.y) = state.pose.pose.position.y + xt::cumsum(dy * model_dt, 1);
+  xt::noalias(trajectories.x) = state.pose.pose.position.x + xt::cumsum(dx * settings_.model_dt, 1);
+  xt::noalias(trajectories.y) = state.pose.pose.position.y + xt::cumsum(dy * settings_.model_dt, 1);
 }
 
 xt::xtensor<float, 2> Optimizer::getOptimizedTrajectory()
 {
-  int time_steps;
-  {
-    std::lock_guard<std::mutex> lock(param_mtx_);
-    time_steps = settings_.time_steps;
-  }
-
-  auto&& sequence =
-      xt::xtensor<float, 2>::from_shape({ static_cast<long unsigned int>(time_steps), isHolonomic() ? 3u : 2u });
-  auto&& trajectories = xt::xtensor<float, 2>::from_shape({ static_cast<long unsigned int>(time_steps), 3 });
+  auto&& sequence = xt::xtensor<float, 2>::from_shape(
+      { static_cast<long unsigned int>(settings_.time_steps), isHolonomic() ? 3u : 2u });
+  auto&& trajectories = xt::xtensor<float, 2>::from_shape({ static_cast<long unsigned int>(settings_.time_steps), 3 });
 
   xt::noalias(xt::view(sequence, xt::all(), 0)) = control_sequence_.vx;
   xt::noalias(xt::view(sequence, xt::all(), 1)) = control_sequence_.wz;
@@ -404,31 +348,25 @@ xt::xtensor<float, 2> Optimizer::getOptimizedTrajectory()
 
 void Optimizer::updateControlSequence()
 {
-  mppi::models::OptimizerSettings settings_copy;
-  {
-    std::lock_guard<std::mutex> lock(param_mtx_);
-    settings_copy = settings_;
-  }
-
   auto bounded_noises_vx = state_.cvx - control_sequence_.vx;
   auto bounded_noises_wz = state_.cwz - control_sequence_.wz;
   xt::noalias(costs_) +=
-      settings_copy.gamma / powf(settings_copy.sampling_std.vx, 2) *
+      settings_.gamma / powf(settings_.sampling_std.vx, 2) *
       xt::sum(xt::view(control_sequence_.vx, xt::newaxis(), xt::all()) * bounded_noises_vx, 1, immediate);
   xt::noalias(costs_) +=
-      settings_copy.gamma / powf(settings_copy.sampling_std.wz, 2) *
+      settings_.gamma / powf(settings_.sampling_std.wz, 2) *
       xt::sum(xt::view(control_sequence_.wz, xt::newaxis(), xt::all()) * bounded_noises_wz, 1, immediate);
 
   if (isHolonomic())
   {
     auto bounded_noises_vy = state_.cvy - control_sequence_.vy;
     xt::noalias(costs_) +=
-        settings_copy.gamma / powf(settings_copy.sampling_std.vy, 2) *
+        settings_.gamma / powf(settings_.sampling_std.vy, 2) *
         xt::sum(xt::view(control_sequence_.vy, xt::newaxis(), xt::all()) * bounded_noises_vy, 1, immediate);
   }
 
   auto&& costs_normalized = costs_ - xt::amin(costs_, immediate);
-  auto&& exponents = xt::eval(xt::exp(-1 / settings_copy.temperature * costs_normalized));
+  auto&& exponents = xt::eval(xt::exp(-1 / settings_.temperature * costs_normalized));
   auto&& softmaxes = xt::eval(exponents / xt::sum(exponents, immediate));
   auto&& softmaxes_extened = xt::eval(xt::view(softmaxes, xt::all(), xt::newaxis()));
 
@@ -478,6 +416,7 @@ void Optimizer::setMotionModel(const int model)
       motion_model_ = std::make_shared<DiffDriveMotionModel>();
       break;
   }
+  is_holonomic_ = motion_model_->isHolonomic();
 }
 
 void Optimizer::setSpeedLimit(double speed_limit, bool percentage)


### PR DESCRIPTION
# Description
wrike: https://www.wrike.com/open.htm?id=1283827864

The parameters are not updated in the `reconfigureCB` anymore, but before we compute the `computeVelocityCommands`.
The `reconfigureCB` is only storing the new configuration to be applied on the next loop.
This logic fixes the problem of possible race-conditions because we are not changing parameters on their own thread, i.e., we change parameters for controller, optimizer, path_handler, noise_generator, etc, in sequence.

In this case, we don't need mutexes because it is single-threaded.
The only thing we need to protect is the `config_` in the `controller`, which can be accessed by two threads.

The video below shows dynamic reconfiguration of several parameters:

https://github.com/rapyuta-robotics/mppi_controller/assets/6097267/652c472d-9843-411c-85f5-22b954c73f4a

