### PR TITLE
Remove overriding weight and power critic parameters

### DIFF
--- a/include/mppi_controller/critics/obstacles_critic.hpp
+++ b/include/mppi_controller/critics/obstacles_critic.hpp
@@ -97,8 +97,7 @@ protected:
   float near_goal_distance_;
   float circumscribed_cost_{0}, circumscribed_radius_{0};
 
-  unsigned int power_{0};
-  float repulsion_weight_, critical_weight_{ 0 };
+  float repulsion_weight_;
   std::string inflation_layer_name_{ "" };
 };
 

--- a/include/mppi_controller/critics/path_align_legacy_critic.hpp
+++ b/include/mppi_controller/critics/path_align_legacy_critic.hpp
@@ -51,8 +51,6 @@ protected:
   float threshold_to_consider_{0};
   float max_path_occupancy_ratio_{0};
   bool use_path_orientations_{false};
-  unsigned int power_{0};
-  float weight_{0};
 };
 
 }  // namespace mppi::critics

--- a/include/mppi_controller/critics/path_angle_critic.hpp
+++ b/include/mppi_controller/critics/path_angle_critic.hpp
@@ -81,9 +81,6 @@ protected:
   bool reversing_allowed_{true};
   PathAngleMode mode_{0};
 
-  unsigned int power_{0};
-  float weight_{0};
-
 private:
   inline void reconfigureCB(mppi_controller::PathAngleCriticConfig& config, uint32_t level)
   {

--- a/src/critics/path_align_critic.cpp
+++ b/src/critics/path_align_critic.cpp
@@ -66,7 +66,7 @@ void PathAlignCritic::score(CriticData & data)
   // Find integrated distance in the path
   std::vector<float> path_integrated_distances(path_segments_count, 0.0f);
   float dx = 0.0f, dy = 0.0f;
-  for (unsigned int i = 1; i != path_segments_count; i++) {
+  for (unsigned int i = 1; i < path_segments_count; i++) {
     dx = P_x(i) - P_x(i - 1);
     dy = P_y(i) - P_y(i - 1);
     float curr_dist = sqrtf(dx * dx + dy * dy);
@@ -95,6 +95,9 @@ void PathAlignCritic::score(CriticData & data)
 
       // The nearest path point to align to needs to be not in collision, else
       // let the obstacle critic take over in this region due to dynamic obstacles
+      if (data.path_pts_valid->size() <= path_pt) {
+        break;
+      }
       if ((*data.path_pts_valid)[path_pt]) {
         dx = P_x(path_pt) - Tx;
         dy = P_y(path_pt) - Ty;


### PR DESCRIPTION
https://www.wrike.com/open.htm?id=1331172238

This was indeed disabling the 3 critics, as power is 0

The 2nd commit is a bit hackish.  Would be nicer to properly investigate how this happens on the first place
