### PR TITLE
Add new critic so we don't need path_align/use_path_orientations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,7 @@ generate_dynamic_reconfigure_options(
   cfg/PathAlignCritic.cfg
   cfg/PathAngleCritic.cfg
   cfg/PathFollowCritic.cfg
+  cfg/PathHeadingCritic.cfg
   cfg/PreferForwardCritic.cfg
   cfg/TwirlingCritic.cfg
 )
@@ -83,6 +84,7 @@ add_library(mppi_critics SHARED
   src/critics/goal_angle_critic.cpp
   src/critics/path_align_critic.cpp
   src/critics/path_follow_critic.cpp
+  src/critics/path_heading_critic.cpp
   src/critics/path_angle_critic.cpp
   src/critics/prefer_forward_critic.cpp
   src/critics/twirling_critic.cpp

--- a/cfg/PathHeadingCritic.cfg
+++ b/cfg/PathHeadingCritic.cfg
@@ -1,0 +1,17 @@
+#!/usr/bin/env python
+# MPPI Controller configuration
+
+from dynamic_reconfigure.parameter_generator_catkin import ParameterGenerator, double_t, int_t, bool_t
+PACKAGE = "mppi_controller"
+
+gen = ParameterGenerator()
+
+gen.add("enabled", bool_t, 0, "Distance between robot and goal above which goal cost starts being considered", True)
+gen.add("cost_power", double_t, 0, "Power order to apply to term", 0.0, 0.0, 10000.0)
+gen.add("cost_weight", double_t, 0, "Weight to apply to critic term", 0.0, 0.0, 10000.0)
+
+gen.add("max_path_occupancy_ratio", double_t, 0, "Maximum proportion of the path that can be occupied before this critic is not considered to allow the obstacle and path follow critics to avoid obstacles while following the path's intent in presence of dynamic objects in the scene", 0.07, 0.0, 1.0)
+gen.add("threshold_to_consider", double_t, 0, "Distance between robot and goal above which path align cost stops being considered", 0.5, 0.0, 10.0)
+gen.add("offset_from_furthest", int_t, 0, "Checks that the candidate trajectories are sufficiently far along their way tracking the path to apply the alignment critic", 20, 0, 100)
+gen.add("trajectory_point_step", int_t, 0, "Step of trajectory points to evaluate for path distance to reduce compute time", 4, 1, 20)
+exit(gen.generate(PACKAGE, "mppi_controller", "PathHeadingCritic"))

--- a/critics.xml
+++ b/critics.xml
@@ -31,6 +31,12 @@
       <description>mppi critic for aligning to path (legacy)</description>
     </class>
 
+    <class  name="mppi_critics/PathHeadingCritic"
+            type="mppi::critics::PathHeadingCritic"
+            base_class_type="mppi::critics::CriticBase">
+      <description>mppi critic for tracking the path in the correct heading</description>
+    </class>
+
     <class  name="mppi_critics/PathAngleCritic"
             type="mppi::critics::PathAngleCritic"
             base_class_type="mppi::critics::CriticBase">

--- a/include/mppi_controller/critics/obstacles_critic.hpp
+++ b/include/mppi_controller/critics/obstacles_critic.hpp
@@ -97,8 +97,7 @@ protected:
   float near_goal_distance_;
   float circumscribed_cost_{0}, circumscribed_radius_{0};
 
-  unsigned int power_{0};
-  float repulsion_weight_, critical_weight_{ 0 };
+  float repulsion_weight_;
   std::string inflation_layer_name_{ "" };
 };
 

--- a/include/mppi_controller/critics/path_align_legacy_critic.hpp
+++ b/include/mppi_controller/critics/path_align_legacy_critic.hpp
@@ -51,8 +51,6 @@ protected:
   float threshold_to_consider_{0};
   float max_path_occupancy_ratio_{0};
   bool use_path_orientations_{false};
-  unsigned int power_{0};
-  float weight_{0};
 };
 
 }  // namespace mppi::critics

--- a/include/mppi_controller/critics/path_angle_critic.hpp
+++ b/include/mppi_controller/critics/path_angle_critic.hpp
@@ -81,9 +81,6 @@ protected:
   bool reversing_allowed_{true};
   PathAngleMode mode_{0};
 
-  unsigned int power_{0};
-  float weight_{0};
-
 private:
   inline void reconfigureCB(mppi_controller::PathAngleCriticConfig& config, uint32_t level)
   {

--- a/include/mppi_controller/critics/path_heading_critic.hpp
+++ b/include/mppi_controller/critics/path_heading_critic.hpp
@@ -1,0 +1,62 @@
+// Copyright (c) 2023 Open Navigation LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef MPPI_CONTROLLER__CRITICS__PATH_ALIGN_CRITIC_HPP_
+#define MPPI_CONTROLLER__CRITICS__PATH_ALIGN_CRITIC_HPP_
+
+#include "mppi_controller/critic_function.hpp"
+#include "mppi_controller/models/state.hpp"
+#include "mppi_controller/tools/utils.hpp"
+
+#include <mppi_controller/PathHeadingCriticConfig.h>
+
+namespace mppi::critics
+{
+
+/**
+ * @class mppi::critics::ConstraintCritic
+ * @brief Critic objective function for aligning to the path. Note:
+ * High settings of this will follow the path more precisely, but also makes it
+ * difficult (or impossible) to deviate in the presence of dynamic obstacles.
+ * This is an important critic to tune and consider in tandem with Obstacle.
+ */
+class PathHeadingCritic : public CriticFunction<mppi_controller::PathHeadingCriticConfig>
+{
+public:
+  /**
+    * @brief Initialize critic
+    */
+  void initialize() override;
+
+  /**
+   * @brief Evaluate cost related to trajectories path alignment
+   *
+   * @param costs [out] add reference cost values to this tensor
+   */
+  void score(CriticData & data) override;
+
+private:
+  void reconfigureCB(mppi_controller::PathHeadingCriticConfig& config, uint32_t level);
+
+protected:
+  size_t offset_from_furthest_{0};
+  int trajectory_point_step_{0};
+  float threshold_to_consider_{0};
+  float max_path_occupancy_ratio_{0};
+  bool use_path_orientations_{ false };
+};
+
+}  // namespace mppi::critics
+
+#endif  // MPPI_CONTROLLER__CRITICS__PATH_ALIGN_CRITIC_HPP_

--- a/src/critics/path_align_critic.cpp
+++ b/src/critics/path_align_critic.cpp
@@ -66,7 +66,7 @@ void PathAlignCritic::score(CriticData & data)
   // Find integrated distance in the path
   std::vector<float> path_integrated_distances(path_segments_count, 0.0f);
   float dx = 0.0f, dy = 0.0f;
-  for (unsigned int i = 1; i != path_segments_count; i++) {
+  for (unsigned int i = 1; i < path_segments_count; i++) {
     dx = P_x(i) - P_x(i - 1);
     dy = P_y(i) - P_y(i - 1);
     float curr_dist = sqrtf(dx * dx + dy * dy);
@@ -95,6 +95,9 @@ void PathAlignCritic::score(CriticData & data)
 
       // The nearest path point to align to needs to be not in collision, else
       // let the obstacle critic take over in this region due to dynamic obstacles
+      if (data.path_pts_valid->size() <= path_pt) {
+        break;
+      }
       if ((*data.path_pts_valid)[path_pt]) {
         dx = P_x(path_pt) - Tx;
         dy = P_y(path_pt) - Ty;

--- a/src/critics/path_heading_critic.cpp
+++ b/src/critics/path_heading_critic.cpp
@@ -1,0 +1,141 @@
+// Copyright (c) 2023 Open Navigation LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "mppi_controller/critics/path_heading_critic.hpp"
+
+#include <xtensor/xfixed.hpp>
+#include <xtensor/xmath.hpp>
+
+namespace mppi::critics
+{
+
+using namespace xt::placeholders;  // NOLINT
+using xt::evaluation_strategy::immediate;
+
+void PathHeadingCritic::initialize()
+{
+}
+
+void PathHeadingCritic::score(CriticData & data)
+{
+  // Don't apply close to goal, let the goal critics take over
+  if (!enabled_ ||
+    utils::withinPositionGoalTolerance(threshold_to_consider_, data.state.pose.pose, data.path))
+  {
+    return;
+  }
+
+  // Don't apply when first getting bearing w.r.t. the path  TODO maybe remove?
+  utils::setPathFurthestPointIfNotSet(data);
+  const size_t path_segments_count = *data.furthest_reached_path_point;  // up to furthest only
+  if (path_segments_count < offset_from_furthest_) {
+    return;
+  }
+
+  // Don't apply when dynamic obstacles are blocking significant proportions of the local path
+  utils::setPathCostsIfNotSet(data, costmap_ros_);
+  const size_t closest_initial_path_point = utils::findPathTrajectoryInitialPoint(data);
+  unsigned int invalid_ctr = 0;
+  const float range = *data.furthest_reached_path_point - closest_initial_path_point;
+  for (size_t i = closest_initial_path_point; i < *data.furthest_reached_path_point; i++) {
+    if (!(*data.path_pts_valid)[i]) {invalid_ctr++;}
+    if (static_cast<float>(invalid_ctr) / range > max_path_occupancy_ratio_ && invalid_ctr > 2) {
+      return;
+    }
+  }
+
+  const auto P_x = xt::view(data.path.x, xt::range(_, -1));  // path points
+  const auto P_y = xt::view(data.path.y, xt::range(_, -1));  // path points
+  const auto P_yaw = xt::view(data.path.yaws, xt::range(_, -1));  // path points
+
+  const size_t batch_size = data.trajectories.x.shape(0);
+  const size_t time_steps = data.trajectories.x.shape(1);
+  auto && cost = xt::xtensor<float, 1>::from_shape({data.costs.shape(0)});
+
+  // Find integrated distance in the path
+  std::vector<float> path_integrated_distances(path_segments_count, 0.0f);
+  float dx = 0.0f, dy = 0.0f;
+  for (unsigned int i = 1; i < path_segments_count; i++) {
+    dx = P_x(i) - P_x(i - 1);
+    dy = P_y(i) - P_y(i - 1);
+    float curr_dist = sqrtf(dx * dx + dy * dy);
+    path_integrated_distances[i] = path_integrated_distances[i - 1] + curr_dist;
+  }
+
+  float traj_integrated_distance = 0.0f;
+  float summed_path_dist = 0.0f, dyaw = 0.0f;
+  float num_samples = 0.0f;
+  float Tx = 0.0f, Ty = 0.0f;
+  size_t path_pt = 0;
+  for (size_t t = 0; t < batch_size; ++t) {
+    traj_integrated_distance = 0.0f;
+    summed_path_dist = 0.0f;
+    num_samples = 0.0f;
+    const auto T_x = xt::view(data.trajectories.x, t, xt::all());
+    const auto T_y = xt::view(data.trajectories.y, t, xt::all());
+    for (size_t p = trajectory_point_step_; p < time_steps; p += trajectory_point_step_) {
+      Tx = T_x(p);
+      Ty = T_y(p);
+      dx = Tx - T_x(p - trajectory_point_step_);
+      dy = Ty - T_y(p - trajectory_point_step_);
+      traj_integrated_distance += sqrtf(dx * dx + dy * dy);
+      path_pt = utils::findClosestPathPt(
+        path_integrated_distances, traj_integrated_distance, path_pt);
+
+      // The nearest path point to align to needs to be not in collision, else
+      // let the obstacle critic take over in this region due to dynamic obstacles
+      if (data.path_pts_valid->size() <= path_pt)
+      {
+        ROS_ERROR_STREAM_ONCE("petaria"  << "\t" << data.path_pts_valid->size()  << "\t" <<  path_pt);
+        break;
+      }
+      ROS_ASSERT_MSG(data.path_pts_valid->size() > path_pt, "%d <= %d", data.path_pts_valid->size() , path_pt);
+      if ((*data.path_pts_valid)[path_pt]) {
+        dx = P_x(path_pt) - Tx;
+        dy = P_y(path_pt) - Ty;
+        num_samples += 1.0f;
+          const auto T_yaw = xt::view(data.trajectories.yaws, t, xt::all());
+          dyaw = angles::shortest_angular_distance(P_yaw(path_pt), T_yaw(p));
+          summed_path_dist += sqrtf(dyaw * dyaw);
+      }
+    }
+    ROS_ASSERT_MSG(cost.size() > t, "%d <= %d",cost.size() , t);
+    if (num_samples > 0) {
+      cost[t] = summed_path_dist / num_samples;
+    } else {
+      cost[t] = 0.0f;
+    }
+  }
+
+  data.costs += xt::pow(std::move(cost) * weight_, power_);
+
+//  for (auto c : data.costs)
+//    std::cerr << c  << "\t";
+//  std::cerr << "\n";
+}
+
+void PathHeadingCritic::reconfigureCB(mppi_controller::PathHeadingCriticConfig& config, uint32_t level)
+{
+  offset_from_furthest_ = config.offset_from_furthest;
+  trajectory_point_step_ = config.trajectory_point_step;
+  threshold_to_consider_ = config.threshold_to_consider;
+  max_path_occupancy_ratio_ = config.max_path_occupancy_ratio;
+  CriticFunction::reconfigureCB(config, level);
+}
+
+}  // namespace mppi::critics
+
+#include <pluginlib/class_list_macros.hpp>
+
+PLUGINLIB_EXPORT_CLASS(mppi::critics::PathHeadingCritic, mppi::critics::CriticBase)


### PR DESCRIPTION
The new critic is a copy-paste of PathAlignCritic but with only the part enabled by `use_path_orientations`. 
This allow us to fix the problem of robot not spinning to go to a path pointing backward but disabling PathAlignCritic, cause with it robot follows the path too closely 

If we adopt it, better to do a proper cleanup of the uneeded parts. I keep this as draft meanwhile

Configuration
```
  path_heading:
      enabled: true
      cost_power: 1.0
      cost_weight: 5.0
      threshold_to_consider: 0.0  # must be lower than goal distance tolerance
      offset_from_furthest: 1  # ensures robot spins in place before following the path
      trajectory_point_step: 0
      max_path_occupancy_ratio: 0.07
```
And disable `path_align` and `path_angle`