### PR TITLE
Fix nan speeds caused by error on obstacles critic

### DIFF
--- a/src/critics/obstacles_critic.cpp
+++ b/src/critics/obstacles_critic.cpp
@@ -133,6 +133,10 @@ void ObstaclesCritic::score(CriticData& data)
     for (size_t j = 0; j < traj_len; j++)
     {
       pose_cost = costAtPose(traj.x(i, j), traj.y(i, j), traj.yaws(i, j));
+      if (!pose_cost.cost)
+      {
+        continue;
+      }  // In free space, nothing else to do
 
       if (inCollision(pose_cost.cost))
       {


### PR DESCRIPTION
We need to continue when `costAtPose` because otherwise we set the cost to - inf [here](https://github.com/rapyuta-robotics/mppi_controller/blob/9f2dc0ac0d4778cf10a3d4f9c5d4e3bb0ccb8645/src/critics/obstacles_critic.cpp#L165) (dist_to_obj is inf when cost is 0)